### PR TITLE
Make 2019 results archive link more permanent

### DIFF
--- a/archive.html
+++ b/archive.html
@@ -13,7 +13,7 @@ permalink: /archive/
         On February 16, 2019, Science Olympiad at Penn hosted its third Division C Tournament. 47 teams attended the tournament. Troy High School (CA) was crowned champion with an overall score of 120.
     </p>
     <p>
-         <a href="https://app.avogadro.ws/invitational/university-of-pennsylvania-c/">Click here for the 2019 results.</a> Congratulations to all of the participants!
+         <a href="https://unosmium.org/results/2019-02-16_penn_invitational_c">Click here for the 2019 results.</a> Congratulations to all of the participants!
     </p>
     <div class="">
         <h2><span>2018 Tournament</span></h2>


### PR DESCRIPTION
Replaces link to Avogadro (where results are only kept for one year,
dependent on subscription renewal) with link to Unosmium Results (where
results are kept forever, for free).

Disclaimer: this committer is the primary developer for Unosmium
Results (https://github.com/unosmium/unosmium.org).